### PR TITLE
feat: default to current working directory when no plugins are provided

### DIFF
--- a/messages/main.json
+++ b/messages/main.json
@@ -1,6 +1,6 @@
 {
   "commandDescription": "generate the command reference guide located",
-  "pluginFlagDescription": "comma separated list of plugin names to be part of the generation. Defaults to the current working directory if it's a valid oclif plugin.",
+  "pluginFlagDescription": "comma separated list of plugin names to be part of the generation. Defaults to the oclif plugin in the current working directory",
   "hiddenFlagDescription": "show hidden commands",
   "outputdirFlagDescription": "output directory to put generated files",
   "erroronwarningFlagDescription": "fail the command if there are any warnings"

--- a/src/commands/commandreference/generate.ts
+++ b/src/commands/commandreference/generate.ts
@@ -51,7 +51,7 @@ export default class CommandReferenceGenerate extends SfdxCommand {
         pluginNames = [getString(packageJson, 'name')];
       } else {
         throw new SfdxError(
-          'No package.json found in current working directory. Please cd into a directory that contains a valid oclif plugin'
+          'No plugins provided. Provide the \'--plugins\' flag or cd into a directory that contains a valid oclif plugin.'
         );
       }
     } else {


### PR DESCRIPTION
Defaults to the plugin in the current working directory if no plugins are provided with the -p flag