### PR TITLE
Replace dynamic values in examples

### DIFF
--- a/src/ditamap/command.ts
+++ b/src/ditamap/command.ts
@@ -60,10 +60,22 @@ export class Command extends Ditamap {
       }
     }
 
+    let examples;
+    const binary = 'sfdx';
+
+    if (command.examples) {
+      examples = Array.isArray(command.examples) ? command.examples : [command.examples];
+
+      examples = examples.map((example) =>
+        example.replace(/<%= config.bin %>/g, binary).replace(/<%= command.id %>/g, command.id)
+      );
+    }
+
     const state = command.state || commandMeta.state;
     this.data = Object.assign(command, {
-      binary: 'sfdx',
+      binary,
       commandWithUnderscores,
+      examples,
       help,
       description,
       parameters,


### PR DESCRIPTION
[@W-10277470@](https://gus.my.salesforce.com/apex/ADM_WorkLocator?bugorworknumber=W-10277470)

Plugin-info uses `<%= config.bin %>` and `<%= command.id %>` [in its examples](https://github.com/salesforcecli/plugin-info/blob/main/messages/display.js#L7-L15) so that the correct binary and command will be displayed when running help. 

Examples:
- In `sfdx`:
  - `sfdx info:releasenotes:display --version 7.120.0`
- In `sf`:
  - `sf info releasenotes display --version 7.120.0`

However, these values were not replaced in the `sfdx` command reference ([here](https://developer.salesforce.com/docs/atlas.en-us.238.0.sfdx_cli_reference.meta/sfdx_cli_reference/cli_reference_info_releasenotes.htm#cli_reference_info_releasenotes_display)). This PR fixes this. 

## Testing
- Prior to code changes, I ran the following command (from Juliet)
  - `sfdx commandreference:generate --plugins salesforce-alm,alias,apex,auth,config,custom-metadata,data,limits,org,schema,templates,user,@salesforce/sfdx-plugin-lwc-test,source,info,community,signups -d output`
- Committed those generated command reference files
- Added this PR's logic
- Ran the same command
- Did a `git diff` and made sure nothing else was affected
  - Note: the `metadataPackage` is generated, that is why it is different.
<img width="1664" alt="Screen Shot 2022-05-20 at 11 35 16 AM" src="https://user-images.githubusercontent.com/1715111/169577469-f6cb9b1d-96a7-4b57-b798-cb3afec231c9.png">

