### PR TITLE
fix: accept `flag.summary` as desc

### DIFF
--- a/src/ditamap/command.ts
+++ b/src/ditamap/command.ts
@@ -12,6 +12,7 @@ import { Ditamap } from './ditamap';
 
 export type CommandHelpInfo = {
   hidden: boolean;
+  summary: string;
   description: string;
   longDescription: string;
   required: boolean;
@@ -99,9 +100,9 @@ export class Command extends Ditamap {
     return Object.entries(flags)
       .filter(([, flag]) => !flag.hidden)
       .map(([flagName, flag]) => {
-        const description = this.formatParagraphs(flag.longDescription || punctuate(flag.description));
+        const description = this.formatParagraphs(flag.longDescription || punctuate(flag.summary || flag.description));
         if (!flag.longDescription) {
-          flag.longDescription = punctuate(flag.description);
+          flag.longDescription = punctuate(flag.summary || flag.description);
         }
         return Object.assign(flag, {
           name: flagName,


### PR DESCRIPTION
### What does this PR do?

Makes the plugin accept the `summary` field as the flag description, falls back to `flag.description`.
`oclif/core` has the same behaviour:
https://github.com/oclif/core/blob/main/src/parser/help.ts#L25

When a flag doesn't have `summary` or `description` defined you get an error like this when trying to generate the cmd ref:

```
yarn test:command-reference
> Can't create topic for sobject:list: description.split is not a function


Wrote generated doc to ./tmp/root
ERROR running commandreference:generate:  Found 1 warnings.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

### What issues does this PR fix or reference?
@W-12135685@