### PR TITLE
fix: remove usage section of command pages

### DIFF
--- a/templates/cli_reference_xml.hbs
+++ b/templates/cli_reference_xml.hbs
@@ -11,7 +11,7 @@ IF YOU WANT TO CHANGE THIS CONTENT, CONTACT juliet.shackell@salesforce.com FOR D
 -->
     <!--This is a static file that should be passed as-is through the autogen process.-->
     <title>sf</title>
-   <shortdesc>This section contains information about the <codeph otherprops="nolang">sf</codeph> commands and their parameters. </shortdesc>
+    <shortdesc>Commands to manage Salesforce DX projects, create and manage scratch orgs and sandboxes, synchronize source to and from orgs, create and install packages, and more. </shortdesc>
     <prolog>
         <metadata>
             <othermeta content="reference" name="topic_type"/>

--- a/templates/command.hbs
+++ b/templates/command.hbs
@@ -70,17 +70,6 @@ IF YOU WANT TO CHANGE THIS CONTENT, CONTACT juliet.shackell@salesforce.com FOR D
             {{/each}}
         </section>
         {{/if}}
-        <section>
-            <title><ph>Usage</ph></title>
-            <dl>
-                <dlentry>
-                    <dt><codeph otherprops="nolang">{{binary}} {{name}}</codeph></dt>
-                    {{#each parameters}}
-                    <dd>{{#if optional}}[{{/if}}<codeph otherprops="nolang">{{#if char}}-{{char}}{{else}}--{{name}}{{/if}}</codeph>{{#if hasValue}} <parmname>{{toUpperCase name}}</parmname>{{/if}}{{#if optional}}]{{/if}}</dd>
-                    {{/each}}
-                </dlentry>
-            </dl>
-        </section>
         {{#if parameters}}
         <section>
             <title><ph>Flags</ph></title>


### PR DESCRIPTION
Updates the description of the "sf" section of the CLI Ref
Removes the Usage section for each "sf" command because it's not useful, and even confusing and incomplete sometimes.
